### PR TITLE
Code understandability improved

### DIFF
--- a/notebooks/new-31-js-language-overview.md
+++ b/notebooks/new-31-js-language-overview.md
@@ -455,30 +455,31 @@ vector.display()
 
 ```javascript cell_style="split"
 class Temperature {
-    constructor(temp_value) {
-        this.kelvin = temp_value;
-        // "set kelvin(temp_value)" will be called
+    constructor(temperature) {
+        this.kelvin = temperature;
+        // "set kelvin(temperature)" will be called
     }
 
     get kelvin() {
         return this._kelvin;
     }
 
-    set kelvin(temp_value) {
-        if (temp_value < 0) {
+    set kelvin(temperature_value) {
+        if (temperature_value < 0) {
             console.log("negative");
             return;
             // this.kelvin will be undefined
         }
-        this._kelvin = temp_value;
+        this._kelvin = temperature_value;
 
         // we must use the hidden variable this._kelvin
         // that will store the value entered 
         // and will be returned when we ask for this.kelvin
         // thanks to the get kevin() function
         
-        // otherwise, set kelvin(temp_value) is called again
-        // and we have an infinite loop
+        // if we had written this.kelvin = temp_value
+        // that would call set kelvin(temp_value) again
+        // and we would have an infinite loop
 
     }
 }

--- a/notebooks/new-31-js-language-overview.md
+++ b/notebooks/new-31-js-language-overview.md
@@ -455,20 +455,31 @@ vector.display()
 
 ```javascript cell_style="split"
 class Temperature {
-    constructor(kelvin) {
-        this.kelvin = kelvin; // Call "set kelvin(kelvin)"
+    constructor(temp_value) {
+        this.kelvin = temp_value;
+        // "set kelvin(temp_value)" will be called
     }
-    
+
     get kelvin() {
         return this._kelvin;
     }
 
-    set kelvin(kelvin) {
-        if (kelvin < 0) {
+    set kelvin(temp_value) {
+        if (temp_value < 0) {
             console.log("negative");
-            return
+            return;
+            // this.kelvin will be undefined
         }
-        this._kelvin = kelvin;
+        this._kelvin = temp_value;
+
+        // we must use the hidden variable this._kelvin
+        // that will store the value entered 
+        // and will be returned when we ask for this.kelvin
+        // thanks to the get kevin() function
+        
+        // otherwise, set kelvin(temp_value) is called again
+        // and we have an infinite loop
+
     }
 }
 ```


### PR DESCRIPTION
- replace function arg `kelvin` by `temp_value` to avoid confusion
- add explanation for why there is both `this.kelvin` and `this._kelvin`

J'ai passé un peu de temps à comprendre ce passage du fait de la nouveauté du mécanisme d'une part, et d'autre part de la confusion entre les différents `kelvin`. Je vous propose donc cette amélioration 😃 